### PR TITLE
Changed regex split to string tokens. Fixes failure in Ubuntu

### DIFF
--- a/src/riaknostic_check_memory_use.erl
+++ b/src/riaknostic_check_memory_use.erl
@@ -43,11 +43,11 @@ valid() ->
 check() ->
     Pid = riaknostic_node:pid(),
     Output = riaknostic_util:run_command("ps -o pmem,rss -p " ++ Pid),
-    [_,_,Percent, RealSize| _] = re:split(Output, "\s+|\$"),
+    [_,_,Percent, RealSize| _] = string:tokens(Output, "/n \n"),
     Messages = [
                 {info, {process_usage, Percent, RealSize}}
                ],
-    case riaknostic_util:binary_to_float(Percent) >= 90 of
+    case riaknostic_util:binary_to_float(list_to_binary(Percent)) >= 90 of
         false ->
             Messages;
         true ->


### PR DESCRIPTION
Linux prod-26 2.6.32-35-generic #78-Ubuntu SMP showed repeatable error where regex split did not split as expected.  Caused fatal errors in riaknostic_util:binary_to_float where list_to_float failed because input was the RSS data instead of expected percent (i.e. no decimal).
