### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ To install `riaknostic`, download the latest package version, and extract it wit
             <td><code>/opt/riak/lib</code></td>
         </tr>
         <tr>
+            <td>SmartOS (Joyent)</td>
+            <td><code>/opt/local/lib/riak/lib</code></td>
+        </tr>
+        <tr>
             <td>Mac OS/X or Self-built</td>
             <td><code>$RIAK/lib</code>
                 (where <code>$RIAK=rel/riak</code> for source installs,


### PR DESCRIPTION
SmartOS has different paths from standard Solaris, using pkg_add package with current version 1.2
