### PR TITLE
Remove misplaced parathesis (sysctl check)

### DIFF
--- a/src/riaknostic_check_sysctl.erl
+++ b/src/riaknostic_check_sysctl.erl
@@ -84,9 +84,9 @@ check_params([H|T], Acc) ->
                        
 -spec format(term()) -> {io:format(), [term()]}.
 format({good, Param, Actual, Val, Direction}) ->
-    {"~s is ~p ~s ~p)", [Param, Actual, direction_to_word(Direction), Val]};
+    {"~s is ~p ~s ~p", [Param, Actual, direction_to_word(Direction), Val]};
 format({bad, Param, Actual, Val, Direction}) ->
-    {"~s is ~p, should be ~s~p)", [Param, Actual, direction_to_word2(Direction), Val]}.
+    {"~s is ~p, should be ~s~p", [Param, Actual, direction_to_word2(Direction), Val]}.
 
 direction_to_word(Direction) ->
     case Direction of 


### PR DESCRIPTION
#### Before

```
jan@himinbjorg:~$ riak-admin diag
Attempting to restart script through sudo -H -u riak
11:00:52.982 [critical] vm.swappiness is 60, should be no more than 0)
11:00:52.982 [critical] net.core.wmem_default is 229376, should be at least 8388608)
11:00:52.982 [critical] net.core.rmem_default is 229376, should be at least 8388608)
11:00:52.982 [critical] net.core.wmem_max is 131071, should be at least 8388608)
11:00:52.982 [critical] net.core.rmem_max is 131071, should be at least 8388608)
11:00:52.982 [critical] net.core.netdev_max_backlog is 1000, should be at least 10000)
11:00:52.982 [critical] net.core.somaxconn is 128, should be at least 4000)
11:00:52.983 [critical] net.ipv4.tcp_max_syn_backlog is 2048, should be at least 40000)
11:00:52.983 [critical] net.ipv4.tcp_fin_timeout is 60, should be no more than 15)
11:00:52.983 [critical] net.ipv4.tcp_tw_reuse is 0, should be 1)
...
```
#### After

```
jan@himinbjorg:~$ riak-admin diag
Attempting to restart script through sudo -H -u riak
11:00:52.982 [critical] vm.swappiness is 60, should be no more than 0
11:00:52.982 [critical] net.core.wmem_default is 229376, should be at least 8388608
11:00:52.982 [critical] net.core.rmem_default is 229376, should be at least 8388608
11:00:52.982 [critical] net.core.wmem_max is 131071, should be at least 8388608
11:00:52.982 [critical] net.core.rmem_max is 131071, should be at least 8388608
11:00:52.982 [critical] net.core.netdev_max_backlog is 1000, should be at least 10000
11:00:52.982 [critical] net.core.somaxconn is 128, should be at least 4000
11:00:52.983 [critical] net.ipv4.tcp_max_syn_backlog is 2048, should be at least 40000
11:00:52.983 [critical] net.ipv4.tcp_fin_timeout is 60, should be no more than 15
11:00:52.983 [critical] net.ipv4.tcp_tw_reuse is 0, should be 1
...
```
