### PR TITLE
Add OpenBSD bits

### DIFF
--- a/src/riaknostic_check_sysctl.erl
+++ b/src/riaknostic_check_sysctl.erl
@@ -43,6 +43,11 @@
                        {"net.ipv4.tcp_tw_reuse",                1, eq}
                       ]).
 
+-define(OPENBSD_PARAMS, [
+                       {"kern.somaxconn",                    4000, lte}
+                      ]).
+		
+
 -spec description() -> string().
 description() ->
     "Check sysctl tuning parameters".
@@ -55,9 +60,11 @@ valid() ->
 check() ->
     Params = case os:type() of
                  {unix, linux} -> ?LINUX_PARAMS;
+                 {unix, openbsd} -> ?OPENBSD_PARAMS;
                  {unix, darwin} -> []; 
                  {unix, freebsd} -> [];
-                 {unix, sunos} -> []
+                 {unix, sunos} -> [];
+                 _ -> []
              end,
     Recs = check_params(Params),
     Recs.

--- a/src/riaknostic_export.erl
+++ b/src/riaknostic_export.erl
@@ -60,6 +60,9 @@ get_cmd_list() ->
                 {unix, freebsd} ->
                     [
                     ] ++ Stats;
+                {unix, openbsd} ->
+                    [
+                    ] ++ Stats;
                 {unix, sunos} ->
                     [
                     ];
@@ -82,6 +85,9 @@ get_file_list() ->
                     ];
                 {unix, darwin} -> []; % unsupported for production
                 {unix, freebsd} ->
+                    [
+                    ];
+                {unix, openbsd} ->
                     [
                     ];
                 {unix, sunos} ->


### PR DESCRIPTION
This just adds OpenBSD branches to all the os:type case blocks, and adds an OPENBSD_PARAMS containing the only sysctl that we have an equivalent for from the linux set.
