### PR TITLE
Added pattern match to handle timeouts for github Issue 86

### DIFF
--- a/src/riaknostic_node.erl
+++ b/src/riaknostic_node.erl
@@ -191,7 +191,7 @@ append_node_suffix(Name, Suffix) ->
 
 has_stats() ->
     case application:get_env(riaknostic, local_stats) of
-		{ok, {badrpc, _Reason}} -> 
+	{ok, {badrpc, _Reason}} -> 
             false;
         {ok, Stats} ->
             {ok, Stats};

--- a/src/riaknostic_node.erl
+++ b/src/riaknostic_node.erl
@@ -191,6 +191,8 @@ append_node_suffix(Name, Suffix) ->
 
 has_stats() ->
     case application:get_env(riaknostic, local_stats) of
+		{ok, {badrpc, _Reason}} -> 
+            false;
         {ok, Stats} ->
             {ok, Stats};
         undefined ->


### PR DESCRIPTION
# riaknostic Issue #86 -- Timeout message cached in local stats and causes crash

A recent customer issue revealed a condition where their repeated calls to `riak_kv_status:statistics/0` were timing out and storing the `{badrpc, timeout}` message as the stats, causing `riaknostic` to crash.
## Reproducer

```
application:set_env(riaknostic, local_stats, {badrpc, timeout}).
application:get_env(riaknostic, local_stats).
riaknostic:main([]).
```
## Fix

The `riaknostic_node` module is responsible for fetching and caching the stats, so a pattern match was added to the `has_stats/0` function to handle the `{badrpc, Reason}` message and return as if no stats were currently cached so it will refetch in this state.
## Test

```
application:set_env(riaknostic, local_stats, {badrpc, timeout}).
application:get_env(riaknostic, local_stats).
riaknostic:main([]).
{ok, {badrpc, timeout}} =:= application:get_env(riaknostic, local_stats).
```
